### PR TITLE
makefile: make tags by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -54,3 +54,4 @@ indent_size = 4
 # Makefile
 [Makefile]
 indent_size = 4
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ IMAGES=$(ALL_STACKS) gitlab-runner renga-python
 
 GIT_MASTER_HEAD_SHA:=$(shell git rev-parse --short=12 --verify HEAD)
 
-build-docker-images: $(IMAGES:%=build/%)
+tag-docker-images: $(IMAGES:%=tag/%)
 
 build/%-notebook: Dockerfile.notebook.template
 	cat $< | sed "s!%%NOTEBOOK_STACK%%!$(notdir $@)!g;" | docker build --rm --force-rm -t rengahub/$(notdir $@):$(GIT_MASTER_HEAD_SHA) -f - .


### PR DESCRIPTION
tag by default so that proper tags are made when used with the makefile from the renga repo

addresses https://github.com/SwissDataScienceCenter/renga/issues/121 