### PR TITLE
dockerhub: use --password-stdin for login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ push/%: tag/%
 	docker push $(DOCKER_PREFIX)$(notdir $@):$(GIT_MASTER_HEAD_SHA)
 
 login:
-	@docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" ${DOCKER_REGISTRY}
+	@echo "${DOCKER_PASSWORD}" | docker login -u="${DOCKER_USERNAME}" --password-stdin ${DOCKER_REGISTRY}


### PR DESCRIPTION
use `--password-stdin` to avoid questions from docker